### PR TITLE
Use Stadia tile layer for basemap

### DIFF
--- a/notebooks/tempo_powerplants_demo.ipynb
+++ b/notebooks/tempo_powerplants_demo.ipynb
@@ -72,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url=\"https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png\"\n"
+    "url=\"https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png\"\n",
     "api_key = getenv(\"STADIA_API_KEY\")\n",
     "if api_key is not None:\n",
     "    url += f\"?api_key={api_key}\"\n",

--- a/notebooks/tempo_powerplants_demo.ipynb
+++ b/notebooks/tempo_powerplants_demo.ipynb
@@ -32,6 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from os import getenv\n",
     "import glue_jupyter as gj\n",
     "from glue_map.data import RemoteGeoData_ArcGISImageServer, Data\n",
     "from glue_map.map.state import MapViewerState\n",
@@ -71,7 +72,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer_state = MapViewerState(basemap=TileLayer(url=\"https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png\"))\n",
+    "url=\"https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png\"\n"
+    "api_key = getenv(\"STADIA_API_KEY\")\n",
+    "if api_key is not None:\n",
+    "    url += f\"?api_key={api_key}\"\n",
+    "viewer_state = MapViewerState(basemap=TileLayer(url=url))\n",
     "mapviewer = mapapp.new_data_viewer('map', data=tempo_data, state=viewer_state)\n",
     "_ = mapviewer.add_data(data=power_data)"
    ]

--- a/notebooks/tempo_powerplants_demo.ipynb
+++ b/notebooks/tempo_powerplants_demo.ipynb
@@ -34,7 +34,8 @@
    "source": [
     "import glue_jupyter as gj\n",
     "from glue_map.data import RemoteGeoData_ArcGISImageServer, Data\n",
-    "from ipyleaflet import Map, Marker, LayersControl, WidgetControl\n",
+    "from glue_map.map.state import MapViewerState\n",
+    "from ipyleaflet import Map, Marker, LayersControl, TileLayer, WidgetControl\n",
     "from datetime import date, datetime, timezone, timedelta\n",
     "from ipywidgets import SelectionSlider, Layout, Label, VBox, Dropdown, DatePicker\n",
     "import pandas as pd\n",
@@ -70,7 +71,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mapviewer = mapapp.new_data_viewer('map', data=tempo_data)\n",
+    "viewer_state = MapViewerState(basemap=TileLayer(url=\"https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png\"))\n",
+    "mapviewer = mapapp.new_data_viewer('map', data=tempo_data, state=viewer_state)\n",
     "_ = mapviewer.add_data(data=power_data)"
    ]
   },

--- a/notebooks/tempo_powerplants_demo.ipynb
+++ b/notebooks/tempo_powerplants_demo.ipynb
@@ -170,8 +170,8 @@
     "    url += f\"?api_key={api_key}\"\n",
     "viewer_state = MapViewerState(basemap=TileLayer(url=url))\n",
     "mapviewer = mapapp.new_data_viewer('map', data=tempo_data, state=viewer_state, show=False)\n",
-    "powerplant_widget = SubsetControlWidget(power_data, mapviewer)\n",
-    "_ = mapviewer.add_data(data=power_data)"
+    "_ = mapviewer.add_data(data=power_data)\n",
+    "powerplant_widget = SubsetControlWidget(power_data, mapviewer)"
    ]
   },
   {


### PR DESCRIPTION
This PR updates the viewer basemap to be the same Stadia layer that we use for TEMPO Lite.

You can use Stadia for free when running from localhost (as we're planning to do for demoing), but I've also set this to use our API key if `STADIA_API_KEY` is defined in the environment.

This deals with the last item in #3.