### PR TITLE
Use Magma colorscale for TEMPO layer.

### DIFF
--- a/notebooks/tempo_powerplants_demo.ipynb
+++ b/notebooks/tempo_powerplants_demo.ipynb
@@ -71,7 +71,8 @@
    "outputs": [],
    "source": [
     "mapviewer = mapapp.new_data_viewer('map', data=tempo_data)\n",
-    "_ = mapviewer.add_data(data=power_data)"
+    "_ = mapviewer.add_data(data=power_data)\n",
+    "mapviewer.layers[0].state.colorscale = \"Magma\""
    ]
   },
   {
@@ -178,7 +179,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates our notebook to use the Magma colormap for the TEMPO image layer, which (partially) handles the first item in #3.

Per the [ESRI docs](https://developers.arcgis.com/rest/services-reference/enterprise/color-ramp-objects/), one can define a custom color ramp to use, which we could do to try and use torch. The only options seems to be an algorithmic colormap, or a piecewise combination of them.

The three algorithms available for the color ramps are described [here](https://developers.arcgis.com/javascript/latest/api-reference/esri-rest-support-AlgorithmicColorRamp.html). I don't see anything in the [`cmasher` docs](https://cmasher.readthedocs.io/index.html) that would indicate if they use any particular algorithm for generating sequential colormaps. Any thoughts on this would be great.