### PR TITLE
Add app widget

### DIFF
--- a/notebooks/app_demo.ipynb
+++ b/notebooks/app_demo.ipynb
@@ -1,0 +1,69 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3b11894d-70d7-4954-8ba7-b308e21e2115",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['ipyvolume:lasso', 'ipyvolume:circle', 'ipyvolume:rectangle']\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ca6a5653235446d3ad7ce2049409b339",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "TempoApp(extra_widgets={'powerplant': SubsetControlWidget(size_options=['Small', 'Medium', 'Large'], size_sele…"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from tempods.app import TempoApp\n",
+    "\n",
+    "app = TempoApp()\n",
+    "app"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f96b4d7-6de2-4007-a59a-76c77577ce3b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tempods",
+   "language": "python",
+   "name": "tempods"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/tempods/app.py
+++ b/src/tempods/app.py
@@ -1,0 +1,115 @@
+from cosmicds.utils import load_template
+from glue_jupyter.view import Viewer
+import ipyvuetify as v
+from ipyvuetify.VuetifyTemplate import VuetifyTemplate
+from ipywidgets import DOMWidget, widget_serialization
+from traitlets import Dict, Instance
+
+from os import getenv
+import glue_jupyter as gj
+from glue_map.data import RemoteGeoData_ArcGISImageServer, Data
+from glue_map.map.state import MapViewerState
+from tempods.components.subset_control_widget import SubsetControlWidget
+
+from glue.config import colormaps
+from ipyleaflet import Map, Marker, LayersControl, TileLayer, WidgetControl
+from datetime import date, datetime, timezone, timedelta
+from ipywidgets import SelectionSlider, Layout, Label, VBox, Dropdown, DatePicker, HTML, AppLayout
+import pandas as pd
+import numpy as np
+
+
+v.theme.dark = True
+
+
+class TempoApp(v.VuetifyTemplate):
+    template = load_template("app.vue", __file__, traitlet=True).tag(sync=True)
+    viewers = Dict().tag(sync=True, **widget_serialization)
+    # Calling this just "widgets" or "components" caused problems - must be some name clashes with ipyvuetify
+    extra_widgets = Dict().tag(sync=True, **widget_serialization)
+
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.glue_app = gj.jglue()
+        tempo_data = RemoteGeoData_ArcGISImageServer("https://gis.earthdata.nasa.gov/image/rest/services/C2930763263-LARC_CLOUD/",
+                                            name='TEMPO')
+
+        power_data = self.glue_app.load_data("Power_Plants.csv")
+        self.glue_app.add_data(tempo_data)
+
+        # Our remote dataset does not have real components representing latitude and longitude. We link to the only components
+        # it does have so that we can display this on the same viewer without trigger and IncompatibleAttribute error
+        self.glue_app.add_link(self.glue_app.data_collection["Power_Plants"], 'Longitude',  self.glue_app.data_collection["TEMPO"], 'Pixel Axis 0')
+        self.glue_app.add_link(self.glue_app.data_collection["Power_Plants"], 'Latitude', self.glue_app.data_collection["TEMPO"], 'TEMPO_NO2_L3_V03_HOURLY_TROPOSPHERIC_VERTICAL_COLUMN_BETA')
+
+        big = (power_data['Install_MW'] > 100)
+        med = (power_data['Install_MW'] > 10) & (power_data['Install_MW'] <= 100)
+        small = (power_data['Install_MW'] <= 10)
+        power_data.add_component(big*9 + med*4 + small*1, label='Size_binned')
+
+        stadia_url = "https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.png"
+        stadia_api_key = getenv("STADIA_API_KEY")
+        if stadia_api_key is not None:
+            stadia_url += f"?api_key={stadia_api_key}"
+        map_state = MapViewerState(basemap=TileLayer(url=stadia_url))
+        map_viewer = self.glue_app.new_data_viewer("map", data=tempo_data, state=map_state, show=False)
+        powerplant_widget = SubsetControlWidget(power_data, map_viewer)
+
+        self.add_widget(powerplant_widget, "powerplant")
+        self.add_viewer(map_viewer, "map")
+
+        timeseries_viewer = self.glue_app.new_data_viewer('timeseries', data=tempo_data, show=False)
+        timeseries_viewer.figure.axes[1].label_offset = "-50"
+        timeseries_viewer.figure.axes[1].tick_format = ".0f"
+        timeseries_viewer.figure.axes[1].label = "Amount of NO2 (10^14 molecules/cm^2)"
+
+        timeseries_viewer.figure.axes[0].label_offset = "40"
+        timeseries_viewer.figure.axes[0].label = "Time (UTC)"
+
+        self.add_viewer(timeseries_viewer, "timeseries")
+        
+        def convert_from_milliseconds(milliseconds_since_epoch):
+            """Converts milliseconds since epoch to a date-time string in 'YYYY-MM-DDTHH:MM:SSZ' format."""
+            dt = datetime.fromtimestamp((milliseconds_since_epoch)/ 1000, tz=timezone(offset=timedelta(hours=0), name="UTC"))
+            date_time_str = dt.strftime('%H:%M')
+            return date_time_str
+        
+        time_values = tempo_data.get_time_steps(timeseries_viewer.state.t_date)
+        time_strings = [convert_from_milliseconds(t) for t in time_values]  
+        time_options = [(time_strings[i], time_values[i]) for i in range(len(time_values))]
+        
+        slider = SelectionSlider(description='', options=time_options,layout=Layout(width='700px', height='20px'))
+        dt = datetime.fromtimestamp((slider.value)/ 1000, tz=timezone(offset=timedelta(hours=0), name="UTC"))
+        timeseries_viewer.timemark.x = np.array([dt, dt]).astype('datetime64[ms]')
+        
+        date_chooser = DatePicker(description='Pick a Date')
+        date_chooser.value = date(2024, 10, 15)
+        def update_image(change):
+            map_viewer.layers[0].state.timestep = change.new
+            dt = datetime.fromtimestamp((change.new)/ 1000, tz=timezone(offset=timedelta(hours=0), name="UTC"))
+            timeseries_viewer.timemark.x = np.array([dt, dt]).astype('datetime64[ms]')
+        
+        def update_date(change):
+            time_values = tempo_data.get_time_steps(change.new.isoformat())
+            time_strings = [convert_from_milliseconds(t) for t in time_values]  
+            time_options = [(time_strings[i], time_values[i]) for i in range(len(time_values))]
+            slider.options = time_options
+            timeseries_viewer.state.t_date = change.new.isoformat()
+            
+        date_chooser.observe(update_date, 'value')
+        
+        slider.observe(update_image, 'value')
+        control = WidgetControl(widget=slider, position='bottomleft')
+        map_viewer.map.add(control)
+
+    def add_viewer(self, viewer: Viewer, label: str):
+        current_viewers = {k: v for k, v in self.viewers.items()}
+        current_viewers.update({label: viewer._layout})
+        self.viewers = current_viewers
+
+    def add_widget(self, component: VuetifyTemplate, label: str):
+        current_widgets = {k: v for k, v in self.extra_widgets.items()}
+        current_widgets.update({label: component})
+        self.extra_widgets = current_widgets

--- a/src/tempods/app.vue
+++ b/src/tempods/app.vue
@@ -1,0 +1,74 @@
+<template>
+  <v-app id="tempo-app">
+    <v-app-bar
+      app
+      color="primary"
+      dark
+      clipped-right
+      flat
+      height="60"
+    >
+      <v-toolbar-title class="mr-5">
+        <h2>TEMPO Data Story Prototype</h2>
+      </v-toolbar-title>
+      <v-spacer></v-spacer>
+    </v-app-bar>
+    <v-main>
+      <v-content>
+        <v-container fluid id="main-container">
+          <jupyter-widget id="powerplant-widget" :widget="extra_widgets.powerplant" />
+          <jupyter-widget id="map-viewer" :widget="viewers.map" />
+          <jupyter-widget id="timeseries-viewer" :widget="viewers.timeseries" />
+        </v-container>
+      </v-content>
+    </v-main>
+  </v-app>
+</template>
+
+<style>
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: black;
+}
+
+.jp-Notebook,
+.jp-OutputArea-output,
+.jupyter-widgets,
+.jp-Cell,
+.jp-CodeCell,
+.jp-Notebook-cell,
+.jp-mod-noInput,
+.jp-Cell-outputWrapper,
+{
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#rendered_cells {
+  margin: 0 !important;
+  padding: 0 !important;
+  background-color: black !important;
+}
+
+#tempo-app {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+#main-container {
+  display: flex;
+  flex-direction: row;
+}
+
+#map-viewer,
+#timeseries-viewer {
+  width: 600px;
+}
+
+#powerplant-widget {
+  width: 200px;
+}
+</style>

--- a/src/tempods/components/subset_control_widget/subset_control_widget.py
+++ b/src/tempods/components/subset_control_widget/subset_control_widget.py
@@ -15,6 +15,7 @@ class SubsetControlWidget(v.VuetifyTemplate):
     size_selections = List().tag(sync=True)
     type_options = List().tag(sync=True)
     type_selections = List().tag(sync=True)
+    type_colors = List().tag(sync=True)
 
     def __init__(self, data: Data, viewer: Viewer):
         super().__init__()
@@ -27,10 +28,10 @@ class SubsetControlWidget(v.VuetifyTemplate):
         self.size_options = ["Small", "Medium", "Large"]
         self.indices = list(product(range(len(self.type_options)), range(len(self.size_options))))
 
-        type_colors = ["red", "green", "blue", "purple"]
+        self.type_colors = ["red", "green", "blue", "purple"]
         self._layer_indices = {}
         for (idx_t, idx_s) in self.indices:
-            subset = data.new_subset(color=type_colors[idx_t])
+            subset = data.new_subset(color=self.type_colors[idx_t])
             subset.style.markersize = (idx_s + 1) ** 2
             state = self._subset_state(idx_t, idx_s)
             subset.subset_state = state

--- a/src/tempods/components/subset_control_widget/subset_control_widget.vue
+++ b/src/tempods/components/subset_control_widget/subset_control_widget.vue
@@ -25,6 +25,7 @@
             <v-list-item-action>
               <v-checkbox
                 :input-value="active"
+                :color="type_colors[index]"
               />
             </v-list-item-action>
           </template>
@@ -51,6 +52,7 @@
             <v-list-item-action>
               <v-checkbox
                 :input-value="active"
+                :color="gray"
               />
             </v-list-item-action>
           </template>

--- a/src/tempods/components/subset_control_widget/subset_control_widget.vue
+++ b/src/tempods/components/subset_control_widget/subset_control_widget.vue
@@ -20,7 +20,7 @@
             <v-list-item-content
               class="font-weight-bold"
             >
-              {{ option }}
+              {{ toTitleCase(option) }}
             </v-list-item-content>
             <v-list-item-action>
               <v-checkbox
@@ -52,7 +52,7 @@
             <v-list-item-action>
               <v-checkbox
                 :input-value="active"
-                :color="gray"
+                color="gray"
               />
             </v-list-item-action>
           </template>
@@ -61,3 +61,16 @@
     </v-list>
   </v-card>
 </template>
+
+<script>
+export default {
+  methods: {
+    toTitleCase(str) {
+      return str.replace(
+        /\w\S*/g,
+        text => text.charAt(0).toUpperCase() + text.substring(1).toLowerCase()
+      );
+    }
+  }
+}
+</script>


### PR DESCRIPTION
This PR create a `TempoApp` widget which bundles our various widgets together into one ipywidget. I've also added an `app_demo.py` notebook that's an example of what we would want to use with voila to display this.

I also made a few minor styling improvements to the subset control widget - checkboxes now match the power plant type colors, and I've title-cased those names as well.

I really didn't spend any time on the template layout here - I just wanted to get the basics up-and-running.