### PR TITLE
Start with empty selection for both subset categories

### DIFF
--- a/src/tempods/components/subset_control_widget/subset_control_widget.py
+++ b/src/tempods/components/subset_control_widget/subset_control_widget.py
@@ -39,8 +39,9 @@ class SubsetControlWidget(v.VuetifyTemplate):
             index = len(self.viewer.layers) - 1
             self._layer_indices[(idx_t, idx_s)] = index
 
-        self.type_selections = sorted(list(unique(data[self.type_att].codes)))
-        self.size_selections = list(range(len(self.size_options)))
+        self.type_selections = []
+        self.size_selections = []
+        self._update_visibilities(self.type_selections, self.size_selections)
 
         self.observe(self._on_type_selections_changed, names=["type_selections"])
         self.observe(self._on_size_selections_changed, names=["size_selections"])


### PR DESCRIPTION
This PR updates the subset control widget to start with everything unselected. This takes care of the first item in https://github.com/cosmicds/tempods/issues/13.

As a note, we could have every layer have its visibility set off by just having one of the two lists be empty, but I think having them both be empty makes more sense.